### PR TITLE
[feature] Add  Add stock management triggers and soft deletes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,8 @@
       "Bash(npx supabase:*)",
       "Bash(npm run:*)",
       "Bash(git commit:*)",
-      "Bash(git -c user.name=\"Claude Code\" -c user.email=\"claude@anthropic.com\" commit -m \"$(cat <<''EOF''\n[fix] Fix seed file enum values for order status\n\nUpdated seed.sql to use correct order_status enum values:\n- Changed ''shipped'' to ''fulfilled''\n- Changed ''completed'' to ''fulfilled'' \n- Changed ''pending'' to ''draft''\n\nThis resolves database seeding errors and aligns with the schema definition.\n\n🤖 Generated with [Claude Code](https://claude.ai/code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")"
+      "Bash(git -c user.name=\"Claude Code\" -c user.email=\"claude@anthropic.com\" commit -m \"$(cat <<''EOF''\n[fix] Fix seed file enum values for order status\n\nUpdated seed.sql to use correct order_status enum values:\n- Changed ''shipped'' to ''fulfilled''\n- Changed ''completed'' to ''fulfilled'' \n- Changed ''pending'' to ''draft''\n\nThis resolves database seeding errors and aligns with the schema definition.\n\n🤖 Generated with [Claude Code](https://claude.ai/code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")",
+      "Bash(psql:*)"
     ],
     "deny": [],
     "ask": []

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   role                   UserRole
   name                   String
   createdAt              DateTime              @default(now()) @map("created_at")
+  deletedAt              DateTime?             @map("deleted_at")
 
   // Relations
   salesOrders            SaleOrder[]           @relation("Salesperson")
@@ -45,6 +46,7 @@ model User {
   attachmentsUploaded    Attachment[]
   orderStatusChanges     OrderStatusHistory[]
 
+  @@index([deletedAt])
   @@map("users")
 }
 
@@ -60,12 +62,14 @@ model Product {
   stockQuantity          Int                   @map("stock_quantity")
   createdAt              DateTime              @default(now()) @map("created_at")
   updatedAt              DateTime              @updatedAt @map("updated_at")
+  deletedAt              DateTime?             @map("deleted_at")
 
   // Relations
   orderItems             OrderItem[]
 
   @@index([code])
   @@index([category])
+  @@index([deletedAt])
   @@map("products")
 }
 
@@ -83,6 +87,7 @@ model SaleOrder {
   notes                  String                @default("")
   createdAt              DateTime              @default(now()) @map("created_at")
   updatedAt              DateTime              @updatedAt @map("updated_at")
+  deletedAt              DateTime?             @map("deleted_at")
 
   // Relations
   salesperson            User                  @relation("Salesperson", fields: [salespersonId], references: [id])
@@ -94,6 +99,7 @@ model SaleOrder {
 
   @@index([status])
   @@index([salespersonId])
+  @@index([deletedAt])
   @@map("sale_orders")
 }
 

--- a/supabase/migrations/20250915040022_add_stock_triggers_and_soft_deletes.sql
+++ b/supabase/migrations/20250915040022_add_stock_triggers_and_soft_deletes.sql
@@ -1,0 +1,210 @@
+-- Add soft delete columns
+ALTER TABLE products ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE sale_orders ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- Create indexes for soft delete queries
+CREATE INDEX idx_products_deleted_at ON products(deleted_at);
+CREATE INDEX idx_sale_orders_deleted_at ON sale_orders(deleted_at);
+CREATE INDEX idx_users_deleted_at ON users(deleted_at);
+
+-- Create function to handle stock deduction on order fulfillment
+CREATE OR REPLACE FUNCTION handle_order_fulfillment()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only process when order status changes to 'fulfilled'
+    IF OLD.status != 'fulfilled' AND NEW.status = 'fulfilled' THEN
+        -- Deduct stock for all order items
+        UPDATE products
+        SET stock_quantity = stock_quantity - order_items.quantity,
+            updated_at = NOW()
+        FROM order_items
+        WHERE products.id = order_items.product_id
+        AND order_items.order_id = NEW.id
+        AND products.deleted_at IS NULL;
+
+        -- Update order items stock status
+        UPDATE order_items
+        SET is_in_stock = (
+            SELECT CASE
+                WHEN products.stock_quantity >= order_items.quantity THEN true
+                ELSE false
+            END
+            FROM products
+            WHERE products.id = order_items.product_id
+        )
+        WHERE order_id = NEW.id;
+
+        -- Log the status change to history
+        INSERT INTO order_status_history (order_id, previous_status, new_status, changed_by)
+        VALUES (NEW.id, OLD.status::text, NEW.status::text, NEW.warehouse_id);
+    END IF;
+
+    -- Log any status change to history (if not already logged above)
+    IF OLD.status != NEW.status AND NOT (OLD.status != 'fulfilled' AND NEW.status = 'fulfilled') THEN
+        INSERT INTO order_status_history (order_id, previous_status, new_status, changed_by)
+        VALUES (NEW.id, OLD.status::text, NEW.status::text,
+                COALESCE(NEW.warehouse_id, NEW.manager_id, NEW.salesperson_id));
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create function to validate stock availability on order approval
+CREATE OR REPLACE FUNCTION validate_stock_on_approval()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only validate when order status changes to 'approved'
+    IF OLD.status != 'approved' AND NEW.status = 'approved' THEN
+        -- Check if all items have sufficient stock
+        IF EXISTS (
+            SELECT 1
+            FROM order_items oi
+            JOIN products p ON oi.product_id = p.id
+            WHERE oi.order_id = NEW.id
+            AND p.stock_quantity < oi.quantity
+            AND p.deleted_at IS NULL
+        ) THEN
+            RAISE EXCEPTION 'Insufficient stock for one or more items in order %', NEW.id;
+        END IF;
+
+        -- Update stock status for all order items
+        UPDATE order_items
+        SET is_in_stock = (
+            SELECT CASE
+                WHEN products.stock_quantity >= order_items.quantity THEN true
+                ELSE false
+            END
+            FROM products
+            WHERE products.id = order_items.product_id
+            AND products.deleted_at IS NULL
+        )
+        WHERE order_id = NEW.id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create function to handle line item fulfillment
+CREATE OR REPLACE FUNCTION handle_line_item_fulfillment()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only process when line status changes to 'fulfilled'
+    IF OLD.line_status != 'fulfilled' AND NEW.line_status = 'fulfilled' THEN
+        -- Deduct stock for this specific item
+        UPDATE products
+        SET stock_quantity = stock_quantity - NEW.quantity,
+            updated_at = NOW()
+        WHERE id = NEW.product_id
+        AND deleted_at IS NULL;
+
+        -- Validate that stock didn't go negative
+        IF (SELECT stock_quantity FROM products WHERE id = NEW.product_id) < 0 THEN
+            RAISE EXCEPTION 'Insufficient stock for product %', NEW.product_id;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create triggers
+CREATE TRIGGER trigger_order_fulfillment
+    BEFORE UPDATE ON sale_orders
+    FOR EACH ROW
+    EXECUTE FUNCTION handle_order_fulfillment();
+
+CREATE TRIGGER trigger_validate_stock_approval
+    BEFORE UPDATE ON sale_orders
+    FOR EACH ROW
+    EXECUTE FUNCTION validate_stock_on_approval();
+
+CREATE TRIGGER trigger_line_item_fulfillment
+    BEFORE UPDATE ON order_items
+    FOR EACH ROW
+    EXECUTE FUNCTION handle_line_item_fulfillment();
+
+-- Update RLS policies to exclude soft-deleted records
+DROP POLICY "Anyone can view products" ON products;
+CREATE POLICY "Anyone can view active products" ON products
+    FOR SELECT USING (deleted_at IS NULL);
+
+DROP POLICY "Only managers can modify products" ON products;
+CREATE POLICY "Only managers can modify active products" ON products
+    FOR ALL USING (
+        deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM users
+            WHERE id::text = auth.uid()::text
+            AND role = 'manager'
+            AND deleted_at IS NULL
+        )
+    );
+
+DROP POLICY "Users can view relevant orders" ON sale_orders;
+CREATE POLICY "Users can view relevant active orders" ON sale_orders
+    FOR SELECT USING (
+        deleted_at IS NULL AND (
+            salesperson_id::text = auth.uid()::text OR
+            manager_id::text = auth.uid()::text OR
+            warehouse_id::text = auth.uid()::text OR
+            EXISTS (
+                SELECT 1 FROM users
+                WHERE id::text = auth.uid()::text
+                AND role IN ('manager', 'warehouse')
+                AND deleted_at IS NULL
+            )
+        )
+    );
+
+DROP POLICY "Users can update relevant orders" ON sale_orders;
+CREATE POLICY "Users can update relevant active orders" ON sale_orders
+    FOR UPDATE USING (
+        deleted_at IS NULL AND (
+            (salesperson_id::text = auth.uid()::text AND status = 'draft') OR
+            (EXISTS (
+                SELECT 1 FROM users
+                WHERE id::text = auth.uid()::text
+                AND role IN ('manager', 'warehouse')
+                AND deleted_at IS NULL
+            ))
+        )
+    );
+
+DROP POLICY "Users can view own profile" ON users;
+CREATE POLICY "Users can view own active profile" ON users
+    FOR SELECT USING (auth.uid()::text = id::text AND deleted_at IS NULL);
+
+DROP POLICY "Users can update own profile" ON users;
+CREATE POLICY "Users can update own active profile" ON users
+    FOR UPDATE USING (auth.uid()::text = id::text AND deleted_at IS NULL);
+
+-- Add soft delete function
+CREATE OR REPLACE FUNCTION soft_delete_user(user_id UUID)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE users
+    SET deleted_at = NOW()
+    WHERE id = user_id AND deleted_at IS NULL;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION soft_delete_product(product_id UUID)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE products
+    SET deleted_at = NOW()
+    WHERE id = product_id AND deleted_at IS NULL;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION soft_delete_order(order_id UUID)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE sale_orders
+    SET deleted_at = NOW()
+    WHERE id = order_id AND deleted_at IS NULL;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
[feat] Complete Phase 2: Add stock management triggers and soft deletes

  - Add soft delete columns (deleted_at) to users, products, and sale_orders tables      
  - Implement stock deduction triggers for automatic inventory management:
    * handle_order_fulfillment() - deducts stock when orders are fulfilled
    * validate_stock_on_approval() - validates stock availability on approval
    * handle_line_item_fulfillment() - supports partial fulfillment by line item
  - Add automatic order status history logging for all status changes
  - Update RLS policies to exclude soft-deleted records
  - Create soft delete functions with SECURITY DEFINER for controlled access
  - Update Prisma schema to include soft delete fields and indexes
  - Add comprehensive stock validation to prevent negative inventory

  This completes Phase 2 requirements from the development plan with robust
  business logic, data integrity, and audit trails ready for API development.